### PR TITLE
Add pipenv install for api

### DIFF
--- a/dx2.0/dind-contents/root-ara/api/Dockerfile
+++ b/dx2.0/dind-contents/root-ara/api/Dockerfile
@@ -2,7 +2,7 @@ FROM 666583083672.dkr.ecr.ap-northeast-2.amazonaws.com/newara:develop
 
 WORKDIR /newara/www
 
-RUN apt-get update && apt-get install netcat-openbsd supervisor gettext git vim curl default-mysql-client htop nano zsh -y
+RUN apt-get update && apt-get install netcat-openbsd supervisor gettext git vim less curl default-mysql-client htop nano zsh -y
 RUN curl -L https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh | sh
 RUN chsh -s `which zsh`
 
@@ -15,6 +15,8 @@ RUN mv tmp_repo/.git .
 RUN rm -rf tmp_repo
 # remove inconsistancy btw git repo and api image
 RUN git checkout -- .
+# remove requirements.txt (it is for production)
+RUN rm requirements.txt
 
 RUN ln -s /newara/www /root/api
 WORKDIR /root/api

--- a/dx2.0/dind-contents/root-ara/api/Dockerfile
+++ b/dx2.0/dind-contents/root-ara/api/Dockerfile
@@ -6,6 +6,9 @@ RUN apt-get update && apt-get install netcat-openbsd supervisor gettext git vim 
 RUN curl -L https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh | sh
 RUN chsh -s `which zsh`
 
+RUN pipenv install --dev
+# RUN echo 'eval "$(pipenv shell)"' >> /root/.zshrc
+
 # enable git into existing folder
 RUN git clone -b develop https://github.com/sparcs-kaist/new-ara-api.git tmp_repo
 RUN mv tmp_repo/.git .


### PR DESCRIPTION
https://github.com/sparcs-kaist/new-ara-api/pull/388 대응 PR입니다.
위의 PR이 머지가 되야 정상적으로 작동합니다.

## 기존 개발자 수정 사항
api의 기존 패키지 관리 방식이 poetry에서 pipenv로 바뀜에 따라서 필수적으로 아래 작업을 해주셔야 합니다.

1. 개발중인 모든 commit push (@ api container)
2. `dc down` (@ dind)
3. `docker volume rm ara_vol-api`
4. 해당 코드 반영
[dx2.0/dind-contents/root-ara/api/Dockerfile](https://github.com/sparcs-kaist/new-ara-dx/compare/pipenv?expand=1#diff-1c4e9c87d9e02e96a6451ff6e0bd06ce38a54cb9f82c17d927c407eb8ad70d5e)
5. `dc pull; dc up -d --build`

주의)
- 기존 `source .venv/bin/activate` 가 사라짐에 따라서 자동으로 가상환경이 활성화가 되지 않을 수 있습니다. VSCode의 터미널 창을 껐다 켜시거나, `pipenv shell` 을 통해서 직접 켜 주시기 바랍니다.
- VSCode의 경우 터미널 탭을 새로 여는 경우 자동으로 감지해 켜 주는 것 같긴 합니다. (반드시 zsh의 앞 부분에 `(www)` prefix가 있는지 확인하거나, `pip list | grep black` 을 했을때 패키지가 존재하는지 확인해 주세요.)
- VSCode 처음 접속시 Pylance 관련 오류가 뜨는 경우 Reload를 눌러주시기 바랍니다.

