### PR TITLE
Add init process for web-dev

### DIFF
--- a/dx2.0/dind-contents/root-ara/web-dev/Dockerfile
+++ b/dx2.0/dind-contents/root-ara/web-dev/Dockerfile
@@ -19,4 +19,6 @@ WORKDIR /root/web
 RUN npm install
 
 EXPOSE 8080
-ENTRYPOINT ["sleep", "infinity"]
+RUN apt-get install dumb-init -y
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
https://www.notion.so/sparcs/Too-many-open-files-98577249ad2e46b0a613c1f0273d7b19?pvs=4

Too many open files 에러 관련해서 찾아보다가 web-dev 컨테이너 내부의 좀비 프로세스가 reap 되지 않음을 발견
=> init 프로세스 하나를 추가해주면 정상 작동합니다.

https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/
https://blog.hyojun.me/4